### PR TITLE
Changed integration naming from 'benningsolar' to 'benningsolarinverter'

### DIFF
--- a/custom_components/benningsolarinverter/const.py
+++ b/custom_components/benningsolarinverter/const.py
@@ -1,3 +1,3 @@
 """Constants for the HASS Benning Solar Inverter Integration integration."""
 
-DOMAIN = "benningsolar"
+DOMAIN = "benningsolarinverter"

--- a/custom_components/benningsolarinverter/manifest.json
+++ b/custom_components/benningsolarinverter/manifest.json
@@ -1,5 +1,5 @@
 {
-  "domain": "benningsolar",
+  "domain": "benningsolarinverter",
   "name": "Benning Solar Inverter",
   "codeowners": [
     "@simaxme"


### PR DESCRIPTION
This integration is primarily thought to provide features for the inverter provided by Benning. To avoid any future conflicts, I changed the name to "benningsolarinverter".