### PR TITLE
Added device_class property to entities

### DIFF
--- a/custom_components/benningsolarinverter/benning_entity.py
+++ b/custom_components/benningsolarinverter/benning_entity.py
@@ -1,9 +1,10 @@
 from functools import cached_property
+from typing import override
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 
 from .utils import parse_number
@@ -78,7 +79,48 @@ class BenningEntity(SensorEntity, CoordinatorEntity):
 
     @cached_property
     def native_unit_of_measurement(self):
+        if self._unit == "W/m^2":
+            return "W/m²"
+
         return self._unit
+
+    @cached_property
+    @override
+    def device_class(self) -> SensorDeviceClass | None:
+        if self._unit in ["mWh", "Wh", "kWh", "MWh", "GWh", "TWh"]:
+            return SensorDeviceClass.ENERGY
+
+        if self._unit in ["mW", "W", "kW", "MW"]:
+            return SensorDeviceClass.POWER
+
+        if self._unit in ["°C"]:
+            return SensorDeviceClass.TEMPERATURE
+
+        if self._unit in ["A", "mA"]:
+            return SensorDeviceClass.CURRENT
+
+        if self._unit in ["V", "mV", "kV", "MV"]:
+            return SensorDeviceClass.VOLTAGE
+
+        if self._unit in ["VA", "mVA", "kVA"]:
+            return SensorDeviceClass.APPARENT_POWER
+
+        if self._unit in ["W/m²", "W/m^2"]:
+            return SensorDeviceClass.IRRADIANCE
+
+        if self._unit in ["h"]:
+            return SensorDeviceClass.DURATION
+
+        if self._unit in ["Hz"]:
+            return SensorDeviceClass.FREQUENCY
+
+        return None
+
+    @cached_property
+    def extra_state_attributes(self) -> dict:
+        return {
+            "oid": self._oid
+        }
 
     @cached_property
     def device_info(self) -> DeviceInfo:


### PR DESCRIPTION
This PR adds device class properties to the sensor entities.
This may be useful if you want to integrate some entities to the power tab of HASS.